### PR TITLE
refactor: restructure log metadata to include timestamp, service and traceId

### DIFF
--- a/src/logGenerator.js
+++ b/src/logGenerator.js
@@ -20,12 +20,12 @@ class LogGenerator {
     const level = this.randomSelect(this.logLevels)
 
     return {
-      timestamp: new Date().toISOString(),
-      service: service,
       level: level,
       message: this.randomSelect(this.messages[level]),
-      traceId: uuidv4(),
       metadata: {
+        timestamp: new Date().toISOString(),
+        service: service,
+        traceId: uuidv4(),
         host: this.randomSelect(this.hosts),
         pid: Math.floor(Math.random() * 9999),
         ip: this.generateIP(),


### PR DESCRIPTION
This pull request includes a small but important restructuring of the log generation in the `LogGenerator` class within the `src/logGenerator.js` file. The main change involves moving the `timestamp`, `service`, and `traceId` fields into the `metadata` object.

Changes to log generation:

* [`src/logGenerator.js`](diffhunk://#diff-3bf0a22a237641f9dc9a1f522717a64896bd7ce5d8070aafa31a8ba345b2d2c1L23-R28): Moved `timestamp`, `service`, and `traceId` fields into the `metadata` object to better organize log metadata.