### PR TITLE
refactor: change logger level to debug and add log file clearing functionality

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -30,7 +30,7 @@ const snapLog = createLogger({
 });
 
 const winstonLogger = winston.createLogger({
-  level: "info",
+  level: "debug",
   format: winston.format.json(),
   transports: [
     new winston.transports.File({
@@ -38,6 +38,15 @@ const winstonLogger = winston.createLogger({
     }),
   ],
 });
+
+async function clearLogFiles() {
+  try {
+    await fs.promises.writeFile(path.join(logDir, 'snaplog-benchmark.log'), '', { flag: 'w' });
+    await fs.promises.writeFile(path.join(logDir, 'winston-benchmark.log'), '', { flag: 'w' });
+  } catch (error) {
+    console.error('Error clearing log files:', error);
+  }
+}
 
 async function collectGarbage() {
   if (global.gc) {
@@ -49,6 +58,9 @@ async function collectGarbage() {
 
 async function benchmark(logger, loggerName) {
   console.log(`\nPreparing benchmark for ${loggerName}...`);
+
+  // Clear log files
+  await clearLogFiles();
 
   // Force garbage collection
   await collectGarbage();


### PR DESCRIPTION
This pull request includes several changes to the `benchmark.js` file to enhance logging and ensure log files are cleared before running benchmarks. The most important changes include modifying the log level, adding a function to clear log files, and invoking this function in the benchmark process.

Logging improvements:

* Changed the log level of `winstonLogger` from "info" to "debug" to capture more detailed log information.

Log file management:

* Added an `async` function `clearLogFiles` to clear the contents of log files before running benchmarks. This ensures that each benchmark starts with fresh log files.
* Updated the `benchmark` function to call `clearLogFiles` before forcing garbage collection, ensuring that logs are cleared at the start of each benchmark.