### PR TITLE
refactor: update directory structure from test to benchmark for log files and data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 
-test/testData/
+benchmark/testData/
 
-test/logs/
+benchmark/logs/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ snaplog/
 │   │   └── fileTransport.js    # File output handling logic
 │   └── utils/
 │       └── constants.js        # Log level definitions and constants
-└── test/
+└── benchmark/
     ├── logs/                   # Directory for benchmark output files
     │   ├── snaplog-benchmark.log
     │   ├── snaplog-filtered.log
@@ -52,7 +52,7 @@ const logger = createLogger({
   fileOptions: {
     filename: 'demo.log',
     format: 'json',
-    logDir: './test/logs'
+    logDir: './benchmark/logs'
   }
 });
 
@@ -70,7 +70,7 @@ logger.log('error', 'Query failed');           // Filtered out
 
 **What's Happening?**
 
-1. `createLogger`: Initializes a logger that outputs JSON to test/logs/demo.log.
+1. `createLogger`: Initializes a logger that outputs JSON to benchmark/logs/demo.log.
 2. `logger.log`: Writes messages with specified levels (e.g., 'info', 'error').
 3. `addPatternFilter`: Applies KMP to filter out logs containing "failed".
 4. **Result**: demo.log contains only `{ "level": "info", "message": "Server started successfully" }` and `{ "level": "info", "message": "Database connected" }`.
@@ -110,18 +110,18 @@ Check that your folder contains these key files:
 - `src/utils/constants.js`: Log levels.
 - `benchmark.js`: Benchmark script comparing SnapLog and Winston.
 - `package.json`: Project metadata and scripts.
-- Optional: `src/logGenerator.js` and `test/testData/10000_logs.json` (if provided).
+- Optional: `src/logGenerator.js` and `benchmark/testData/10000_logs.json` (if provided).
 
 ### Step 4: Generate Test Logs (Optional)
 
-If `test/testData/10000_logs.json` isn't included, generate test data:
+If `benchmark/testData/10000_logs.json` isn't included, generate test data:
 
 ```bash
 npm run generate-logs
 ```
 
 - Requires `src/logGenerator.js` (if not present, see note below).
-- Creates `test/testData/10000_logs.json` with 10,000 log entries (mix of levels, some with "failed").
+- Creates `benchmark/testData/10000_logs.json` with 10,000 log entries (mix of levels, some with "failed").
 - **Note**: If `logGenerator.js` isn't provided, you'll need a sample JSON file with entries like `{ "level": "info", "message": "Test log", "metadata": {} }`. Contact me or create one manually.
 
 ### Step 5: Prepare the Logs Directory
@@ -129,10 +129,10 @@ npm run generate-logs
 Ensure the output directory exists:
 
 ```bash
-mkdir -p test/logs
+mkdir -p benchmark/logs
 ```
 
-- Creates `test/logs/` for benchmark output files (snaplog-benchmark.log, etc.).
+- Creates `benchmark/logs/` for benchmark output files (snaplog-benchmark.log, etc.).
 
 ### Step 6: Run the Benchmark
 
@@ -146,7 +146,7 @@ npm run benchmark
 - Performs two tests:
   - **Raw Logging**: Logs all entries without filtering.
   - **Filtered Logging**: Filters out logs with "failed".
-- Outputs results to the terminal and files in `test/logs/`.
+- Outputs results to the terminal and files in `benchmark/logs/`.
 
 ### Step 7: Analyze the Results
 
@@ -156,10 +156,10 @@ npm run benchmark
 - "Performance Comparison": SnapLog vs. Winston (SnapLog should be faster with KMP).
 
 **Log Files**:
-- `test/logs/snaplog-benchmark.log`: Raw logs.
-- `test/logs/winston-benchmark.log`: Raw logs.
-- `test/logs/snaplog-filtered.log`: Filtered logs.
-- `test/logs/winston-filtered.log`: Filtered logs.
+- `benchmark/logs/snaplog-benchmark.log`: Raw logs.
+- `benchmark/logs/winston-benchmark.log`: Raw logs.
+- `benchmark/logs/snaplog-filtered.log`: Filtered logs.
+- `benchmark/logs/winston-filtered.log`: Filtered logs.
 - Verify filtering: Check `*-filtered.log` files—no logs should contain "failed".
 
 ### Step 8: Test SnapLog Manually (Optional)
@@ -173,7 +173,7 @@ const logger = createLogger({
   fileOptions: { 
     filename: 'test.log', 
     format: 'json', 
-    logDir: './test/logs' 
+    logDir: './benchmark/logs' 
   } 
 });
 
@@ -189,7 +189,7 @@ Run it:
 node test.js
 ```
 
-Check `test/logs/test.log` and `test/logs/test2.log`.
+Check `benchmark/logs/test.log` and `benchmark/logs/test2.log`.
 
 ## Expected Outcome
 
@@ -200,7 +200,7 @@ Check `test/logs/test.log` and `test/logs/test2.log`.
 ## Troubleshooting
 
 - "Cannot find module": Rerun `npm install`.
-- No logs in `test/logs/`: Ensure `10000_logs.json` exists and is valid.
+- No logs in `benchmark/logs/`: Ensure `10000_logs.json` exists and is valid.
 - Benchmark fails: Check Node.js version; run `node --expose-gc benchmark.js` manually.
 
 ## Why SnapLog?

--- a/benchmark.js
+++ b/benchmark.js
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename);
 
 let logs;
 try {
-  logs = JSON.parse(fs.readFileSync("./test/testData/1000000_logs.json", "utf8"));
+  logs = JSON.parse(fs.readFileSync("./benchmark/testData/10000_logs.json", "utf8"));
 } catch (error) {
   console.error(chalk.red("Error loading test data:"), error);
   process.exit(1);

--- a/src/logGenerator.js
+++ b/src/logGenerator.js
@@ -42,7 +42,7 @@ class LogGenerator {
   }
 
   generateLogFile(numberOfLogs, filename) {
-    const testDataDir = path.join(__dirname, "../test/testData")
+    const testDataDir = path.join(__dirname, "../benchmark/testData")
     if (!fs.existsSync(testDataDir)) {
       fs.mkdirSync(testDataDir, { recursive: true })
     }
@@ -51,7 +51,7 @@ class LogGenerator {
     const logs = Array.from({ length: numberOfLogs }, () => this.generateLogEntry())
 
     fs.writeFileSync(filePath, JSON.stringify(logs, null, 2))
-    console.log(`Generated ${numberOfLogs} logs in test/testData/${filename}`)
+    console.log(`Generated ${numberOfLogs} logs in benchmark/testData/${filename}`)
   }
 }
 


### PR DESCRIPTION
This pull request includes updates to the `README.md`, `benchmark.js`, and `src/logGenerator.js` files to rename the `test` directory to `benchmark` for improved clarity and organization. The most important changes include updating directory paths and references throughout the documentation and code.

Updates to directory paths and references:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Changed all references from `test/logs` to `benchmark/logs` and from `test/testData` to `benchmark/testData` to reflect the new directory structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R135) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R149) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L159-R162) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R176) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L192-R192) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L203-R203)
* [`benchmark.js`](diffhunk://#diff-3b1a849d2d6aae13f09119215d5d3d658845febd3b000384bec07843e40afb5cL14-R14): Updated the path for loading test data from `./test/testData/1000000_logs.json` to `./benchmark/testData/10000_logs.json`.
* [`src/logGenerator.js`](diffhunk://#diff-3bf0a22a237641f9dc9a1f522717a64896bd7ce5d8070aafa31a8ba345b2d2c1L45-R45): Modified the directory path for generating log files from `../test/testData` to `../benchmark/testData`. [[1]](diffhunk://#diff-3bf0a22a237641f9dc9a1f522717a64896bd7ce5d8070aafa31a8ba345b2d2c1L45-R45) [[2]](diffhunk://#diff-3bf0a22a237641f9dc9a1f522717a64896bd7ce5d8070aafa31a8ba345b2d2c1L54-R54)