### PR TITLE
feat: implement Aho-Corasick algorithm for multi-pattern matching in logs

### DIFF
--- a/src/algorithms/ahoCorasick.js
+++ b/src/algorithms/ahoCorasick.js
@@ -1,7 +1,66 @@
 'use strict';
 
-const findMultiplePatterns = (patterns, logs) => {
-  return [];
+const createTrie = () => ({
+  root: { children: {}, fail: null, outputs: [] },
+  patterns: []
+});
+
+const addPatternToTrie = (trie, pattern) => {
+  const newTrie = {
+    root: { ...trie.root, children: { ...trie.root.children } },
+    patterns: [...trie.patterns, pattern]
+  };
+  let node = newTrie.root;
+  for (const char of pattern) {
+    node.children[char] = node.children[char] || { children: {}, fail: null, outputs: [] };
+    node = node.children[char];
+  }
+  node.outputs.push(pattern);
+  return newTrie;
 };
 
-export { findMultiplePatterns };
+const buildFailureLinks = (trie) => {
+  const newTrie = {
+    root: { ...trie.root, children: { ...trie.root.children } },
+    patterns: [...trie.patterns]
+  };
+  newTrie.root.fail = newTrie.root;
+
+  const queue = [];
+  for (const char in newTrie.root.children) {
+    const child = { ...newTrie.root.children[char], children: { ...newTrie.root.children[char].children } };
+    newTrie.root.children[char] = child;
+    child.fail = newTrie.root;
+    queue.push(child);
+  }
+
+  while (queue.length) {
+    const node = queue.shift();
+    for (const char in node.children) {
+      const child = { ...node.children[char], children: { ...node.children[char].children } };
+      node.children[char] = child;
+      let fail = node.fail;
+      while (fail !== newTrie.root && !fail.children[char]) fail = fail.fail;
+      child.fail = fail.children[char] || newTrie.root;
+      child.outputs = [...child.outputs, ...child.fail.outputs];
+      queue.push(child);
+    }
+  }
+  return newTrie;
+};
+
+const findMultiplePatterns = (patterns, text, trie) => {
+  if (!patterns || !text || !trie) return false;
+  let node = trie.root;
+  const matches = [];
+  for (let i = 0; i < text.length; i++) {
+    while (node !== trie.root && !node.children[text[i]]) node = node.fail;
+    node = node.children[text[i]] || trie.root;
+    if (node.outputs.length) {
+      matches.push(...node.outputs.map(pattern => ({ pattern, end: i })));
+    }
+  }
+  return matches.some(match => patterns.includes(match.pattern));
+};
+
+export { createTrie, addPatternToTrie, buildFailureLinks, findMultiplePatterns };


### PR DESCRIPTION
This pull request enhances the Aho-Corasick algorithm implementation and integrates it into the logging system. The changes include creating a trie structure for pattern matching, adding patterns to the trie, building failure links, and updating the logger to support multi-pattern filters.

Enhancements to Aho-Corasick algorithm:

* [`src/algorithms/ahoCorasick.js`](diffhunk://#diff-43554a6d0c259966dd47cc6fd4527e7d9fb2712d8e7728f0f6a0d29e639c2417L3-R66): Added functions to create a trie, add patterns to the trie, build failure links, and find multiple patterns in a text using the trie.

Integration with logging system:

* [`src/snaplog.js`](diffhunk://#diff-fea7b71e9d980c4b9d179233b9d5ca3561028525698733bd185d26865ed6e4ceL6-R15): Updated imports to include new Aho-Corasick functions.
* [`src/snaplog.js`](diffhunk://#diff-fea7b71e9d980c4b9d179233b9d5ca3561028525698733bd185d26865ed6e4ceL6-R15): Initialized the Aho-Corasick trie in the logger state.
* [`src/snaplog.js`](diffhunk://#diff-fea7b71e9d980c4b9d179233b9d5ca3561028525698733bd185d26865ed6e4ceR46-R58): Added `addMultiPatternFilter` method to the logger, allowing the addition of filters that match multiple patterns using the Aho-Corasick algorithm.
* [`src/snaplog.js`](diffhunk://#diff-fea7b71e9d980c4b9d179233b9d5ca3561028525698733bd185d26865ed6e4ceR103-R107): Updated the logger's `findMultiplePatterns` method to use the Aho-Corasick trie.