### PR TITLE
fix: streamline CI coverage reporting by updating coveralls command in workflow and package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,11 @@ jobs:
         run: npm install
 
       - name: Run Jest Tests and Report Coverage
-        run: npm run test:coverage | coveralls
+        run: npm run test:coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       - name: Upload Coverage to Coveralls
-        run: |
-          npm install --save-dev coveralls
-          coveralls < coverage/lcov-report/lcov-report.json
+        run: npm run coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "coveralls": "cat ./coverage/lcov-report/lcov-report.html | coveralls",
     "perf:generate": "node perf/logGenerator.js",
     "perf:benchmark": "node --expose-gc perf/benchmark.js"
   },


### PR DESCRIPTION
This pull request includes changes to the CI workflow and `package.json` to streamline the process of running tests and uploading coverage reports to Coveralls.

Improvements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R33): Simplified the steps for running Jest tests and uploading coverage to Coveralls by combining commands and removing redundant steps.

Updates to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R10): Added a new script `coveralls` to handle the upload of coverage reports to Coveralls.