### PR TITLE
chore: update Node.js version to 20 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change updates the Node.js version used in the CI workflow from version 16 to version 20.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL22-R22): Updated the Node.js version from '16' to '20' to ensure compatibility with the latest features and improvements.