### PR TITLE
fix: update coveralls command in package.json for correct coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "coveralls": "cat ./coverage/lcov-report/lcov-report.html | coveralls",
+    "coveralls": "coveralls < ./coverage/lcov.info",
     "perf:generate": "node perf/logGenerator.js",
     "perf:benchmark": "node --expose-gc perf/benchmark.js"
   },


### PR DESCRIPTION
This pull request includes a small but important change to the `package.json` file, specifically updating the `coveralls` script to use the correct input file for coverage reporting.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10): Changed the `coveralls` script to read from `./coverage/lcov.info` instead of `./coverage/lcov-report/lcov-report.html`.