### PR TITLE
fix: update CI workflow to check coverage file and use Coveralls GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,12 @@ jobs:
 
       - name: Run Jest Tests and Report Coverage
         run: npm run test:coverage
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+      - name: Check Coverage File
+        run: ls -la ./coverage && cat ./coverage/lcov.info || echo "Coverage file missing"
 
       - name: Upload Coverage to Coveralls
-        run: npm run coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov.info


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration in the `.github/workflows/ci.yml` file. The most important changes include adding a step to check the coverage file and updating the method for uploading coverage to Coveralls.

CI workflow updates:

* Added a step to check the coverage file by listing its contents and displaying the `lcov.info` file, or indicating if the coverage file is missing.
* Updated the step for uploading coverage to Coveralls to use the `coverallsapp/github-action` with the `github-token` and `path-to-lcov` inputs, replacing the previous method that used `npm run coveralls` and the `COVERALLS_REPO_TOKEN` environment variable.